### PR TITLE
Point to actual leases page

### DIFF
--- a/dhcp_leases.inc
+++ b/dhcp_leases.inc
@@ -1,4 +1,4 @@
 <?php
 
 $dhcp_leases_title = gettext('DHCP leases');
-$dhcp_leases_title_link = 'status_dhcp_leases.php';
+$dhcp_leases_title_link = 'ui/dhcpv4/leases';


### PR DESCRIPTION
The link of "DHCP Leases" pointed to `status_dhcp_leases.php`, which is unknown in OPNsense 23.07. The actual DHCPv4 leases are found under: `ui/dhcpv4/leases`